### PR TITLE
Fix timing issue during pairing, add pairing control/status methods

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -77,9 +77,12 @@ setEventHandler	KEYWORD2
 setAdvertisingInterval	KEYWORD2
 setConnectionInterval	KEYWORD2
 setConnectable	KEYWORD2
+setPairable	KEYWORD2
 setTimeout	KEYWORD2
 debug	KEYWORD2
 noDebug	KEYWORD2
+pairable	KEYWORD2
+paired	KEYWORD2
 
 properties	KEYWORD2
 valueSize	KEYWORD2

--- a/src/local/BLELocalDevice.cpp
+++ b/src/local/BLELocalDevice.cpp
@@ -214,6 +214,16 @@ bool BLELocalDevice::connected() const
   return ATT.connected();
 }
 
+/*
+ * Whether there is at least one paired device
+ */
+bool BLELocalDevice::paired()
+{
+  HCI.poll();
+
+  return ATT.paired();
+}
+
 bool BLELocalDevice::disconnect()
 {
   return ATT.disconnect();
@@ -395,6 +405,22 @@ void BLELocalDevice::setTimeout(unsigned long timeout)
   ATT.setTimeout(timeout);
 }
 
+/*
+ * Control whether pairing is allowed or rejected
+ * Use true/false or the Pairable enum
+ */
+void BLELocalDevice::setPairable(uint8_t pairable)
+{
+  L2CAPSignaling.setPairingEnabled(pairable);
+}
+
+/*
+ * Whether pairing is currently allowed
+ */
+bool BLELocalDevice::pairable()
+{
+  return L2CAPSignaling.isPairingEnabled();
+}
 
 void BLELocalDevice::setGetIRKs(int (*getIRKs)(uint8_t* nIRKs, uint8_t** BADDR_type, uint8_t*** BADDRs, uint8_t*** IRKs)){
   HCI._getIRKs = getIRKs;

--- a/src/local/BLELocalDevice.h
+++ b/src/local/BLELocalDevice.h
@@ -24,6 +24,12 @@
 #include "BLEService.h"
 #include "BLEAdvertisingData.h"
 
+enum Pairable {
+  NO = 0,
+  YES = 1,
+  ONCE = 2,
+};
+
 class BLELocalDevice {
 public:
   BLELocalDevice();
@@ -80,6 +86,10 @@ public:
 
   virtual void debug(Stream& stream);
   virtual void noDebug();
+  
+  virtual void setPairable(uint8_t pairable);
+  virtual bool pairable();
+  virtual bool paired();
 
 /// TODO: Put in actual variable names
   virtual void setStoreIRK(int (*storeIRK)(uint8_t*, uint8_t*));

--- a/src/utility/ATT.cpp
+++ b/src/utility/ATT.cpp
@@ -497,6 +497,32 @@ bool ATTClass::connected(uint16_t handle) const
   return false;
 }
 
+/*
+ * Return true if any of the known devices is paired (peer encrypted)
+ * Does not check if the paired device is also connected
+ */
+bool ATTClass::paired() const
+{
+  for(int i=0; i<ATT_MAX_PEERS; i++){
+    if((_peers[i].encryption & PEER_ENCRYPTION::ENCRYPTED_AES) > 0){
+      return true;
+    }
+  }
+  return false;
+}
+
+/*
+ * Return true if the specified device is paired (peer encrypted)
+ */
+bool ATTClass::paired(uint16_t handle) const
+{  
+  for(int i=0; i<ATT_MAX_PEERS; i++){
+    if(_peers[i].connectionHandle != handle){continue;}
+    return (_peers[i].encryption & PEER_ENCRYPTION::ENCRYPTED_AES) > 0;
+  }
+  return false; // unknown handle
+}
+
 uint16_t ATTClass::mtu(uint16_t handle) const
 {
   for (int i = 0; i < ATT_MAX_PEERS; i++) {

--- a/src/utility/ATT.h
+++ b/src/utility/ATT.h
@@ -75,6 +75,8 @@ public:
   virtual bool connected() const;
   virtual bool connected(uint8_t addressType, const uint8_t address[6]) const;
   virtual bool connected(uint16_t handle) const;
+  virtual bool paired() const;
+  virtual bool paired(uint16_t handle) const;
   virtual uint16_t mtu(uint16_t handle) const;
 
   virtual bool disconnect();

--- a/src/utility/HCI.h
+++ b/src/utility/HCI.h
@@ -111,6 +111,7 @@ public:
   // TODO: Send command be private again & use ATT implementation within ATT.
   virtual int sendCommand(uint16_t opcode, uint8_t plen = 0, void* parameters = NULL);
   uint8_t remotePublicKeyBuffer[64];
+  uint8_t remoteDHKeyCheckBuffer[16];
   uint8_t Na[16];
   uint8_t Nb[16];
   uint8_t DHKey[32];

--- a/src/utility/HCI.h
+++ b/src/utility/HCI.h
@@ -22,6 +22,8 @@
 
 #include <Arduino.h>
 
+#include "L2CAPSignaling.h"
+
 #define OGF_LINK_CTL           0x01
 #define OGF_HOST_CTL           0x03
 #define OGF_INFO_PARAM         0x04

--- a/src/utility/L2CAPSignaling.h
+++ b/src/utility/L2CAPSignaling.h
@@ -64,9 +64,15 @@ public:
 
   virtual void setSupervisionTimeout(uint16_t supervisionTimeout);
 
+
+
+  virtual void smCalculateLTKandConfirm(uint16_t handle, uint8_t expectedEa[]);
+
+
 private:
   virtual void connectionParameterUpdateRequest(uint16_t handle, uint8_t identifier, uint8_t dlen, uint8_t data[]);
   virtual void connectionParameterUpdateResponse(uint16_t handle, uint8_t identifier, uint8_t dlen, uint8_t data[]);
+
 
 private:
   uint16_t _minInterval;

--- a/src/utility/L2CAPSignaling.h
+++ b/src/utility/L2CAPSignaling.h
@@ -41,8 +41,15 @@
 #define CONNECTION_PAIRING_DHKEY_CHECK    0x0D
 #define CONNECTION_PAIRING_KEYPRESS       0x0E
 
+#define IOCAP_DISPLAY_ONLY         0x00
+#define IOCAP_DISPLAY_YES_NO       0x01
+#define IOCAP_KEYBOARD_ONLY        0x02
+#define IOCAP_NO_INPUT_NO_OUTPUT   0x03
+#define IOCAP_KEYBOARD_DISPLAY     0x04
+
+
 #define LOCAL_AUTHREQ 0b00101101
-#define LOCAL_IOCAP   0x3
+#define LOCAL_IOCAP   IOCAP_NO_INPUT_NO_OUTPUT // will use JustWorks pairing
 
 class L2CAPSignalingClass {
 public:
@@ -63,6 +70,9 @@ public:
   virtual void setConnectionInterval(uint16_t minInterval, uint16_t maxInterval);
 
   virtual void setSupervisionTimeout(uint16_t supervisionTimeout);
+  
+  virtual void setPairingEnabled(uint8_t enabled);
+  virtual bool isPairingEnabled();
 
 
 
@@ -78,6 +88,7 @@ private:
   uint16_t _minInterval;
   uint16_t _maxInterval;
   uint16_t _supervisionTimeout;
+  uint8_t _pairing_enabled;
 };
 
 extern L2CAPSignalingClass& L2CAPSignaling;


### PR DESCRIPTION
_As disussed in https://github.com/arduino-libraries/ArduinoBLE/issues/36#issuecomment-753920680_

This solves the issues I encountered with the DHKey not yet available when the check is received [here](https://github.com/unknownconstant/ArduinoBLE/blob/7ecf2994ea58a3074f142079a6034de06eb1ad5a/src/utility/L2CAPSignaling.cpp#L293) or the DHKey computation completing during the call to `HCI.readBdAddr()` [here](https://github.com/unknownconstant/ArduinoBLE/blob/7ecf2994ea58a3074f142079a6034de06eb1ad5a/src/utility/L2CAPSignaling.cpp#L291) causing an outdated `encryptionState` to be assumed.

